### PR TITLE
Update Dockerfile with the latest kobim/sqs-insight master version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-from node:alpine
-env commit a32e126
-run apk update && apk upgrade && \
+FROM node:alpine
+ARG COMMIT=d6f264b
+RUN apk update && apk upgrade && \
  apk add --virtual build-dependencies git && \
  apk add jq && \
  git clone -n https://github.com/kobim/sqs-insight.git && \
  cd /sqs-insight && \
- git checkout ${commit} && \
+ git checkout ${COMMIT} && \
  yarn install && \
  apk del build-dependencies && \
  rm -rf /var/cache/apk/*
-copy conf/config.json.* /
-copy init.sh /init.sh
-workdir /sqs-insight
-cmd /init.sh
+COPY conf/config.json.* /
+COPY init.sh /init.sh
+WORKDIR /sqs-insight
+CMD /init.sh


### PR DESCRIPTION
Adds possibility to override the commit hash by:

docker-compose.yml
```
sqs-insight:
    ports:
      - "3000:3000"
    build:
      context: docker/sqs-insight
      args: [ "COMMIT=d6f264b" ]
    depends_on:
      - sqs
```
And Dockerfile:
```
FROM realies/sqs-insight
```

@realies :-)